### PR TITLE
Fix broken article link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **This is "Career as Code"**: one source of truth that generates tailored cover letters, ATS-friendly resumes, and interview prep materials in minutes.
 
-📖 **[Read the full story](#why-this-exists---full-article)** about how this system was built and why it works.
+📖 **[Read the full story](article/article_linkedin_20250907.md)** about how this system was built and why it works.
 
 ---
 


### PR DESCRIPTION
## Summary
Fixed broken article link in README.md that was pointing to a non-existent fragment anchor.

## Changes
- Updated article link from `#why-this-exists---full-article` to `article/article_linkedin_20250907.md`
- Ensures users can access the full article about the system's development

## Type
- Bug fix / Documentation improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)